### PR TITLE
Address issue #1 by allowing use of a different path to python

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,6 +6,7 @@ ssl_country: ''
 ssl_state: ''
 ssl_city: ''
 ssl_org: ''
+python_path: /usr/local/bin
 
 # test users
 generate_testusers: False

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,8 +8,8 @@ ssl_city: ''
 ssl_org: ''
 python_path: /usr/local/bin
 
-# Set to some value, to override automatic value:
-#jupyterhub_ip:
+# Set to some truthy value to override automatic value:
+jupyterhub_ip: false
 jupyterhub_port: 8000
 
 # test users

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,6 +8,10 @@ ssl_city: ''
 ssl_org: ''
 python_path: /usr/local/bin
 
+# Set to some value, to override automatic value:
+#jupyterhub_ip:
+jupyterhub_port: 8000
+
 # test users
 generate_testusers: False
 gen_test_username: ''

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 
 ## Jupyterhub essential yum packages
-- name: check if repel repo is available
+- name: check if epel repo is available
   yum: name=epel-release state=present update_cache=yes
 
 - name: make sure necessary yum packages are installed

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -120,7 +120,7 @@
   register: config_exists
 
 - name: configure jupyterhub
-  command: "{{ pythonpath }}/jupyterhub --generate-config chdir=/etc/jupyterhub/ creates=/etc/jupyterhub/jupyterhub_config.py"
+  command: "{{ python_path }}/jupyterhub --generate-config chdir=/etc/jupyterhub/ creates=/etc/jupyterhub/jupyterhub_config.py"
   when: config_exists.stat.exists == False
 
 # jupyterhub config: python imports

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -136,31 +136,30 @@
 
 # jupyterhub config:: ip addresses
 
-- name: determine default IP address for services
+- name: determine IP address for services
   set_fact:
-    jupyterhub_ip: {{ ansible_eth0.ipv4.address }}
-  when: ! jupyterhub_ip|bool
+    jupyterhub_ip_guts: '{{ jupyterhub_ip or ansible_eth0.ipv4.address }}'
 
 - debug:
-    var: jupyterhub_ip
+    var: jupyterhub_ip_guts
     verbosity: 1
 
 - name: jupyterhub config - set IP address
   lineinfile:
     dest: /etc/jupyterhub/jupyterhub_config.py
-    line: "c.JupyterHub.hub_ip = '{{jupyterhub_ip}}'"
+    line: "c.JupyterHub.hub_ip = '{{jupyterhub_ip_guts}}'"
     regexp: '^c.JupyterHub.hub_ip ='
 
 - name: jupyterhub config - set IP address
   lineinfile:
     dest: /etc/jupyterhub/jupyterhub_config.py
-    line: "c.JupyterHub.ip = '{{jupyterhub_ip}}'"
+    line: "c.JupyterHub.ip = '{{jupyterhub_ip_guts}}'"
     regexp: '^c.JupyterHub.ip ='
 
 - name: jupyterhub config - set IP address
   lineinfile:
     dest: /etc/jupyterhub/jupyterhub_config.py
-    line: "c.JupyterHub.proxy_api_ip = '{{jupyterhub_ip}}'"
+    line: "c.JupyterHub.proxy_api_ip = '{{jupyterhub_ip_guts}}'"
     regexp: '^c.JupyterHub.proxy_api_ip ='
 
 # jupyterhub config:: port number
@@ -169,7 +168,7 @@
   lineinfile:
     dest: /etc/jupyterhub/jupyterhub_config.py
     line: "c.JupyterHub.port = {{ jupyterhub_port }}"
-    regexp: "^c.jupyterHub.port ="
+    regexp: "^c.JupyterHub.port ="
 
 # config: select spawner
 - name: jupyterhub config - set sudo spawner

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -100,10 +100,15 @@
   copy: src=requirements.txt dest=/root/jupyterhub_requirements.txt
 
 - name: install jupyter packages via pip3
-  pip: executable="{{ python_path }}/pip3" requirements="/root/jupyterhub_requirements.txt" extra_args='--upgrade'
+  pip:
+    executable: "{{ python_path }}/pip3"
+    requirements: "/root/jupyterhub_requirements.txt"
+    extra_args: '--upgrade'
 
 - name: install jupyterlab
-  pip: executable="{{ python_path }}/pip3 name=jupyterlab
+  pip:
+    executable: "{{ python_path }}/pip3"
+    name: jupyterlab
   when: jupyterhub_spawner == 'sudospawner-lab'
 
 - name: register jupyterlab
@@ -130,6 +135,7 @@
   lineinfile: dest=/etc/jupyterhub/jupyterhub_config.py line="c.PAMAuthenticator.service = 'login'"
 
 # jupyterhub config:: ip addresses
+
 - name: jupyterhub config - set IP address
   lineinfile: dest=/etc/jupyterhub/jupyterhub_config.py line="c.JupyterHub.hub_ip = '{{ansible_eth0.ipv4.address}}'"
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -100,14 +100,14 @@
   copy: src=requirements.txt dest=/root/jupyterhub_requirements.txt
 
 - name: install jupyter packages via pip3
-  pip: executable=/usr/local/bin/pip3 requirements="/root/jupyterhub_requirements.txt" extra_args='--upgrade'
+  pip: executable="{{ python_path }}/pip3" requirements="/root/jupyterhub_requirements.txt" extra_args='--upgrade'
 
 - name: install jupyterlab
-  pip: executable=/usr/local/bin/pip3 name=jupyterlab
+  pip: executable="{{ python_path }}/pip3 name=jupyterlab
   when: jupyterhub_spawner == 'sudospawner-lab'
 
 - name: register jupyterlab
-  command: /usr/local/bin/jupyter serverextension enable --py jupyterlab --sys-prefix
+  command: "{{ python_path }}/jupyter serverextension enable --py jupyterlab --sys-prefix"
   when: jupyterhub_spawner == 'sudospawner-lab'
 
 - name: Check to see if config file exists
@@ -115,7 +115,7 @@
   register: config_exists
 
 - name: configure jupyterhub
-  command: /usr/local/bin/jupyterhub --generate-config chdir=/etc/jupyterhub/ creates=/etc/jupyterhub/jupyterhub_config.py
+  command: "{{ pythonpath }}/jupyterhub --generate-config chdir=/etc/jupyterhub/ creates=/etc/jupyterhub/jupyterhub_config.py"
   when: config_exists.stat.exists == False
 
 # jupyterhub config: python imports

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -92,7 +92,12 @@
   file: path=/etc/jupyterhub state=directory mode=0755 owner=jupyterhub group=jupyter
 
 - name: copy jupyterhub sudospawner sudo config
-  copy: src=sudo_jupyter dest=/etc/sudoers.d/jupyter mode=0440 owner=root group=root
+  template:
+    src: sudo_jupyter.j2
+    dest: /etc/sudoers.d/jupyter
+    mode: 0440
+    owner: root
+    group: root
   when: jupyterhub_spawner == 'sudospawner' or jupyterhub_spawner == 'sudospawner-lab'
 
 # jupyterhub: python packahes and config
@@ -167,8 +172,8 @@
 - name: jupyterhub config - set proxy port
   lineinfile:
     dest: /etc/jupyterhub/jupyterhub_config.py
-    line: "c.JupyterHub.port = {{ jupyterhub_port }}"
-    regexp: "^c.JupyterHub.port ="
+    line: 'c.JupyterHub.port = {{ jupyterhub_port }}'
+    regexp: '^c.JupyterHub.port ='
 
 # config: select spawner
 - name: jupyterhub config - set sudo spawner
@@ -266,10 +271,6 @@
   lineinfile: dest=/etc/jupyterhub/jupyterhub_config.py line="c.JupyterHub.confirm_no_ssl = True"
   when: nossl == True
 
-- name: Check to see if config file exists
-  stat: path=/lib/systemd/system/jupyterhub.service
-  register: init_exists
-
 # add test users
 - name: add test users
   user: name={{item}} groups=jupyter append=yes state=present password={{gen_test_userpass}}
@@ -285,7 +286,12 @@
 
 # starting the service
 - name: install jupyterhub init script
-  copy: src=jupyterhub.service dest=/lib/systemd/system/jupyterhub.service mode=755 owner=root group=root
+  template:
+    src: jupyterhub.service.j2
+    dest: /lib/systemd/system/jupyterhub.service
+    owner: root
+    group: root
+    mode: 0644
 
 - name: start jupyterhub
   service: name=jupyterhub enabled=yes state=started

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -17,7 +17,7 @@
 
 ## PAM auth and SELinux settings
 - name: (SELinux) yum packages
-  yum: name={{item}} state=latest 
+  yum: name={{item}} state=latest
   with_items:
     - checkpolicy
     - policycoreutils
@@ -60,7 +60,7 @@
 
 - name: (docker) create a docker group
   group: name=docker state=present
-  
+
 - name: (docker) add jupyterhub to docker
   command: usermod -aG docker jupyterhub
 
@@ -136,14 +136,40 @@
 
 # jupyterhub config:: ip addresses
 
-- name: jupyterhub config - set IP address
-  lineinfile: dest=/etc/jupyterhub/jupyterhub_config.py line="c.JupyterHub.hub_ip = '{{ansible_eth0.ipv4.address}}'"
+- name: determine default IP address for services
+  set_fact:
+    jupyterhub_ip: {{ ansible_eth0.ipv4.address }}
+  when: ! jupyterhub_ip|bool
+
+- debug:
+    var: jupyterhub_ip
+    verbosity: 1
 
 - name: jupyterhub config - set IP address
-  lineinfile: dest=/etc/jupyterhub/jupyterhub_config.py line="c.JupyterHub.ip = '{{ansible_eth0.ipv4.address}}'"
+  lineinfile:
+    dest: /etc/jupyterhub/jupyterhub_config.py
+    line: "c.JupyterHub.hub_ip = '{{jupyterhub_ip}}'"
+    regexp: '^c.JupyterHub.hub_ip ='
 
 - name: jupyterhub config - set IP address
-  lineinfile: dest=/etc/jupyterhub/jupyterhub_config.py line="c.JupyterHub.proxy_api_ip = '{{ansible_eth0.ipv4.address}}'"
+  lineinfile:
+    dest: /etc/jupyterhub/jupyterhub_config.py
+    line: "c.JupyterHub.ip = '{{jupyterhub_ip}}'"
+    regexp: '^c.JupyterHub.ip ='
+
+- name: jupyterhub config - set IP address
+  lineinfile:
+    dest: /etc/jupyterhub/jupyterhub_config.py
+    line: "c.JupyterHub.proxy_api_ip = '{{jupyterhub_ip}}'"
+    regexp: '^c.JupyterHub.proxy_api_ip ='
+
+# jupyterhub config:: port number
+
+- name: jupyterhub config - set proxy port
+  lineinfile:
+    dest: /etc/jupyterhub/jupyterhub_config.py
+    line: "c.JupyterHub.port = {{ jupyterhub_port }}"
+    regexp: "^c.jupyterHub.port ="
 
 # config: select spawner
 - name: jupyterhub config - set sudo spawner
@@ -225,7 +251,7 @@
 
 - name: create self-signed SSL cert
   command: openssl req -new -nodes -x509 -subj "/C={{ssl_country}}/ST={{ssl_state}}/L={{ssl_city}}/O={{ssl_org}}/CN=${ansible_fqdn}" -days 3650 -keyout /etc/jupyterhub/server.key -out /etc/jupyterhub/server.crt -extensions v3_ca creates=/etc/jupyterhub/server.crt
-  when: 
+  when:
     - nossl == False
     - cert_exists.stat.exists == False
 

--- a/templates/jupyterhub.service.j2
+++ b/templates/jupyterhub.service.j2
@@ -5,7 +5,7 @@ After=network.target firewalld.service
 [Service]
 User=jupyterhub
 Environment='PYTHONPATH=/etc/jupyterhub'
-ExecStart=/usr/local/bin/jupyterhub
+ExecStart={{ python_path }}/jupyterhub
 WorkingDirectory=/etc/jupyterhub
 
 [Install]

--- a/templates/sudo_jupyter.j2
+++ b/templates/sudo_jupyter.j2
@@ -1,6 +1,6 @@
 # the command(s) the Hub can run on behalf of the above users without needing a password
 # the exact path may differ, depending on how sudospawner was installed
-Cmnd_Alias JUPYTER_CMD = /usr/local/bin/sudospawner
+Cmnd_Alias JUPYTER_CMD = {{ python_path }}/sudospawner
 
 # actually give the Hub user permission to run the above command on behalf
 # of the above users without prompting for a password


### PR DESCRIPTION
See two the following two ansible roles for how we are planning to use this:

* https://github.com/NLM-OCCS/occs-docker - an ansible role to install docker-ce
* https://github.com/NLM-OCCS/occsab-python - an ansible role to install python from RH SCL